### PR TITLE
Small adjustments to simplify tests readability

### DIFF
--- a/tests/test_data/impl_stubs.py
+++ b/tests/test_data/impl_stubs.py
@@ -1,5 +1,7 @@
-from getgauge.python import before_step, step, after_step, before_scenario, after_scenario, before_spec, after_spec, \
-    before_suite, after_suite, screenshot, continue_on_failure
+from getgauge.python import (before_step, step, after_step, before_scenario,
+                             after_scenario, before_spec, after_spec,
+                             before_suite, after_suite, screenshot,
+                             continue_on_failure)
 
 
 @step("Step 1")

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,5 +1,5 @@
-import socket
-import unittest
+from socket import socket, AF_INET, SOCK_STREAM
+from unittest import TestCase, main
 
 from getgauge.messages.messages_pb2 import Message, StepValidateResponse
 from getgauge.messages.spec_pb2 import ProtoExecutionResult, Parameter
@@ -8,7 +8,7 @@ from getgauge.python import DataStoreFactory, DataStore
 from getgauge.registry import registry
 
 
-class ProcessorTests(unittest.TestCase):
+class ProcessorTests(TestCase):
     def setUp(self):
         DataStoreFactory.suite_data_store().clear()
         DataStoreFactory.spec_data_store().clear()
@@ -20,7 +20,10 @@ class ProcessorTests(unittest.TestCase):
 
     def test_Processor_kill_request(self):
         with self.assertRaises(SystemExit):
-            processors[Message.KillProcessRequest](None, None, socket.socket(socket.AF_INET, socket.SOCK_STREAM))
+            processors[Message.KillProcessRequest](None,
+                                                   None,
+                                                   socket(AF_INET,
+                                                          SOCK_STREAM))
 
     def test_Processor_suite_data_store_init_request(self):
         DataStoreFactory.suite_data_store().put('suite', 'value')
@@ -31,8 +34,11 @@ class ProcessorTests(unittest.TestCase):
         processors[Message.SuiteDataStoreInit](None, response, None)
 
         self.assertEqual(Message.ExecutionStatusResponse, response.messageType)
-        self.assertEqual(False, response.executionStatusResponse.executionResult.failed)
-        self.assertEqual(0, response.executionStatusResponse.executionResult.executionTime)
+        self.assertEqual(False,
+                         response.executionStatusResponse.executionResult.failed)
+
+        self.assertEqual(0,
+                         response.executionStatusResponse.executionResult.executionTime)
 
         self.assertEqual(DataStore(), DataStoreFactory.suite_data_store())
 
@@ -431,4 +437,4 @@ def failing_impl():
 
 
 if __name__ == '__main__':
-    unittest.main()
+    main()

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1,15 +1,15 @@
-import unittest
+from unittest import TestCase, main
 
 from getgauge.messages.messages_pb2 import Message
-from getgauge.python import Messages, DataStore, DataStoreFactory, Table, Specification, Scenario, Step, \
-    ExecutionContext, \
-    create_execution_context_from
 from getgauge.registry import registry, _MessagesStore
+from getgauge.python import (Messages, DataStore, DataStoreFactory, Table,
+                             Specification, Scenario, Step, ExecutionContext,
+                             create_execution_context_from)
 
 registry.clear()
 
 
-class MessagesTests(unittest.TestCase):
+class MessagesTests(TestCase):
     def test_pending_messages(self):
         messages = ['HAHAHAH', 'HAHAHAH1', 'HAHAHAH2', 'HAHAHAH3']
         for message in messages:
@@ -45,10 +45,14 @@ class MessagesTests(unittest.TestCase):
         self.assertEqual(messages, pending_messages)
 
 
-class DataStoreTests(unittest.TestCase):
+class DataStoreTests(TestCase):
     def test_data_store(self):
         store = DataStore()
-        values = {'key': 'HAHAHAH', 'key1': 'HAHAHAH1', 'key2': 'HAHAHAH2', 'key3': 'HAHAHAH3'}
+        values = {'key': 'HAHAHAH',
+                  'key1': 'HAHAHAH1',
+                  'key2': 'HAHAHAH2',
+                  'key3': 'HAHAHAH3'}
+
         for value in values:
             store.put(value, value)
 
@@ -60,7 +64,11 @@ class DataStoreTests(unittest.TestCase):
 
     def test_data_store_clear(self):
         store = DataStore()
-        values = {'key': 'HAHAHAH', 'key1': 'HAHAHAH1', 'key2': 'HAHAHAH2', 'key3': 'HAHAHAH3'}
+        values = {'key': 'HAHAHAH',
+                  'key1': 'HAHAHAH1',
+                  'key2': 'HAHAHAH2',
+                  'key3': 'HAHAHAH3'}
+
         for value in values:
             store.put(value, value)
 
@@ -92,7 +100,7 @@ class DataStoreTests(unittest.TestCase):
         self.assertNotEqual(store, store1)
 
 
-class DataStoreFactoryTests(unittest.TestCase):
+class DataStoreFactoryTests(TestCase):
     def test_data_store_factory(self):
         scenario_data_store = DataStoreFactory.scenario_data_store()
         spec_data_store = DataStoreFactory.spec_data_store()
@@ -116,7 +124,7 @@ class ProtoRow:
         self.cells = cells
 
 
-class TableTests(unittest.TestCase):
+class TableTests(TestCase):
     def test_Table(self):
         headers = ['Product', 'Description']
         rows = [{'cells': ['Gauge', 'Test automation with ease']},
@@ -134,10 +142,15 @@ class TableTests(unittest.TestCase):
 
         self.assertEqual(headers, table.headers)
         self.assertEqual(expected_rows, table.rows)
-        self.assertEqual(expected_column_1, table.get_column_values_with_index(1))
-        self.assertEqual(expected_column_2, table.get_column_values_with_index(2))
-        self.assertEqual(expected_column_1, table.get_column_values_with_name(headers[0]))
-        self.assertEqual(expected_column_2, table.get_column_values_with_name(headers[1]))
+        self.assertEqual(expected_column_1,
+                         table.get_column_values_with_index(1))
+        self.assertEqual(expected_column_2,
+                         table.get_column_values_with_index(2))
+        self.assertEqual(expected_column_1,
+                         table.get_column_values_with_name(headers[0]))
+        self.assertEqual(expected_column_2,
+                         table.get_column_values_with_name(headers[1]))
+
         for row in expected_rows:
             self.assertEqual(row, table.get_row(expected_rows.index(row) + 1))
 
@@ -212,7 +225,7 @@ class TableTests(unittest.TestCase):
 |----|-----------|""")
 
 
-class SpecificationTests(unittest.TestCase):
+class SpecificationTests(TestCase):
     def test_Specification(self):
         name = 'NAME'
         file_name = 'FILE_NAME'
@@ -234,7 +247,7 @@ class SpecificationTests(unittest.TestCase):
         self.assertEqual(specification, specification1)
 
 
-class ScenarioTests(unittest.TestCase):
+class ScenarioTests(TestCase):
     def test_Scenario(self):
         name = 'NAME3'
         tags = ['TAGS']
@@ -253,7 +266,7 @@ class ScenarioTests(unittest.TestCase):
         self.assertEqual(scenario, scenario1)
 
 
-class StepTests(unittest.TestCase):
+class StepTests(TestCase):
     def test_Step(self):
         name = 'NAME1'
         step = Step(name, False)
@@ -269,7 +282,7 @@ class StepTests(unittest.TestCase):
         self.assertEqual(step, step1)
 
 
-class ExecutionContextTests(unittest.TestCase):
+class ExecutionContextTests(TestCase):
     def test_ExecutionContextTests(self):
         name = 'NAME'
         file_name = 'FILE_NAME'
@@ -298,14 +311,25 @@ class ExecutionContextTests(unittest.TestCase):
 
     def test_create_execution_context_from(self):
         message = Message()
-        spec_name, spec_file_name, scenario_name, step_name = 'SPEC_NAME', 'SPEC_FILE_NAME', 'SCENARIO_NAME', 'STEP_NAME'
-        message.executionStartingRequest.currentExecutionInfo.currentSpec.name = spec_name
-        message.executionStartingRequest.currentExecutionInfo.currentSpec.fileName = spec_file_name
-        message.executionStartingRequest.currentExecutionInfo.currentSpec.isFailed = True
-        message.executionStartingRequest.currentExecutionInfo.currentScenario.name = scenario_name
-        message.executionStartingRequest.currentExecutionInfo.currentScenario.isFailed = False
-        message.executionStartingRequest.currentExecutionInfo.currentStep.step.actualStepText = step_name
-        message.executionStartingRequest.currentExecutionInfo.currentStep.isFailed = True
+        spec_name = 'SPEC_NAME'
+        spec_file_name = 'SPEC_FILE_NAME'
+        scenario_name = 'SCENARIO_NAME'
+        step_name = 'STEP_NAME'
+
+        message.executionStartingRequest.\
+            currentExecutionInfo.currentSpec.name = spec_name
+        message.executionStartingRequest.\
+            currentExecutionInfo.currentSpec.fileName = spec_file_name
+        message.executionStartingRequest.\
+            currentExecutionInfo.currentSpec.isFailed = True
+        message.executionStartingRequest.\
+            currentExecutionInfo.currentScenario.name = scenario_name
+        message.executionStartingRequest.\
+            currentExecutionInfo.currentScenario.isFailed = False
+        message.executionStartingRequest.\
+            currentExecutionInfo.currentStep.step.actualStepText = step_name
+        message.executionStartingRequest.\
+            currentExecutionInfo.currentStep.isFailed = True
 
         specification = Specification(spec_name, spec_file_name, True, [])
         scenario = Scenario(scenario_name, False, [])
@@ -318,7 +342,7 @@ class ExecutionContextTests(unittest.TestCase):
         self.assertEqual(expected_execution_context, context)
 
 
-class DecoratorTests(unittest.TestCase):
+class DecoratorTests(TestCase):
     def setUp(self):
         from tests.test_data import impl_stubs
         impl_stubs.step1()
@@ -332,8 +356,10 @@ class DecoratorTests(unittest.TestCase):
         step1 = registry.get_info_for('Step 1').impl
         step2 = registry.get_info_for('Step 2').impl
 
-        self.assertEqual(registry.is_continue_on_failure(step1, RuntimeError()), False)
-        self.assertEqual(registry.is_continue_on_failure(step2, RuntimeError()), True)
+        self.assertEqual(
+            registry.is_continue_on_failure(step1, RuntimeError()), False)
+        self.assertEqual(
+            registry.is_continue_on_failure(step2, RuntimeError()), True)
 
     def test_before_step_decorator(self):
         funcs = registry.before_step()
@@ -382,4 +408,4 @@ class DecoratorTests(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    main()

--- a/tests/test_refactor.py
+++ b/tests/test_refactor.py
@@ -50,8 +50,13 @@ def assert_default_vowels(given_vowels):
         actual_data = self.getActualText()
 
         self.assertEqual(Message.RefactorResponse, response.messageType)
-        self.assertEqual(True, response.refactorResponse.success, response.refactorResponse.error)
-        self.assertEqual([RefactorTests.path], response.refactorResponse.filesChanged)
+        self.assertEqual(True,
+                         response.refactorResponse.success,
+                         response.refactorResponse.error)
+
+        self.assertEqual([RefactorTests.path],
+                         response.refactorResponse.filesChanged)
+
         expected = """@step("Vowels in English language is <vowels> <bsdfdsf>.")
 def assert_default_vowels(given_vowels, arg1_bsdfdsf):
     Messages.write_message("Given vowels are {0}".format(given_vowels))
@@ -80,8 +85,13 @@ def assert_default_vowels(given_vowels, arg1_bsdfdsf):
         actual_data = self.getActualText()
 
         self.assertEqual(Message.RefactorResponse, response.messageType)
-        self.assertEqual(True, response.refactorResponse.success, response.refactorResponse.error)
-        self.assertEqual([RefactorTests.path], response.refactorResponse.filesChanged)
+        self.assertEqual(True,
+                         response.refactorResponse.success,
+                         response.refactorResponse.error)
+
+        self.assertEqual([RefactorTests.path],
+                         response.refactorResponse.filesChanged)
+
         expected = """@step("Vowels in English language is <vowels> <vowels!2_ab%$>.")
 def assert_default_vowels(given_vowels, arg1_vowels2_ab):
     Messages.write_message("Given vowels are {0}".format(given_vowels))
@@ -110,8 +120,13 @@ def assert_default_vowels(given_vowels, arg1_vowels2_ab):
         actual_data = self.getActualText()
 
         self.assertEqual(Message.RefactorResponse, response.messageType)
-        self.assertEqual(True, response.refactorResponse.success, response.refactorResponse.error)
-        self.assertEqual([RefactorTests.path], response.refactorResponse.filesChanged)
+        self.assertEqual(True,
+                         response.refactorResponse.success,
+                         response.refactorResponse.error)
+
+        self.assertEqual([RefactorTests.path],
+                         response.refactorResponse.filesChanged)
+
         expected = """@step("Vowels in English language is <vowels> <!%$>.")
 def assert_default_vowels(given_vowels, arg1_):
     Messages.write_message("Given vowels are {0}".format(given_vowels))
@@ -132,8 +147,13 @@ def assert_default_vowels(given_vowels, arg1_):
         actual_data = self.getActualText()
 
         self.assertEqual(Message.RefactorResponse, response.messageType)
-        self.assertEqual(True, response.refactorResponse.success, response.refactorResponse.error)
-        self.assertEqual([RefactorTests.path], response.refactorResponse.filesChanged)
+        self.assertEqual(True,
+                         response.refactorResponse.success,
+                         response.refactorResponse.error)
+
+        self.assertEqual([RefactorTests.path],
+                         response.refactorResponse.filesChanged)
+
         expected = """@step("Vowels in English language is.")
 def assert_default_vowels():
     Messages.write_message("Given vowels are {0}".format(given_vowels))
@@ -159,8 +179,13 @@ def assert_default_vowels():
         actual_data = self.getActualText()
 
         self.assertEqual(Message.RefactorResponse, response.messageType)
-        self.assertEqual(True, response.refactorResponse.success, response.refactorResponse.error)
-        self.assertEqual([RefactorTests.path], response.refactorResponse.filesChanged)
+        self.assertEqual(True,
+                         response.refactorResponse.success,
+                         response.refactorResponse.error)
+
+        self.assertEqual([RefactorTests.path],
+                         response.refactorResponse.filesChanged)
+
         expected = """@step("Vowels in English language is <vowels>.")
 def assert_default_vowels(given_vowels):
     Messages.write_message("Given vowels are {0}".format(given_vowels))
@@ -186,8 +211,13 @@ def assert_default_vowels(given_vowels):
         actual_data = self.getActualText()
 
         self.assertEqual(Message.RefactorResponse, response.messageType)
-        self.assertEqual(True, response.refactorResponse.success, response.refactorResponse.error)
-        self.assertEqual([RefactorTests.path], response.refactorResponse.filesChanged)
+        self.assertEqual(True,
+                         response.refactorResponse.success,
+                         response.refactorResponse.error)
+
+        self.assertEqual([RefactorTests.path],
+                         response.refactorResponse.filesChanged)
+
         expected = """@step("Vowels in English language is <bsdfdsf>.")
 def assert_default_vowels(arg0_bsdfdsf):
     Messages.write_message("Given vowels are {0}".format(given_vowels))

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -252,7 +252,7 @@ class RegistryTests(unittest.TestCase):
         self.assertEqual([info1['func'], info3['func']],
                          registry.after_scenario(['A']))
 
-        sself.assertEqual([info1['func']], registry.after_scenario(['A', 'c']))
+        self.assertEqual([info1['func']], registry.after_scenario(['A', 'c']))
 
     def test_Registry_before_step(self):
         infos = ['before step func', 'before step func1']

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -10,32 +10,42 @@ class RegistryTests(unittest.TestCase):
         registry = Registry()
 
     def test_Registry_add_step_definition(self):
-        infos = [{'text': 'Say <hello> to <getgauge>', 'func': 'func'}, {'text': 'Step 1', 'func': 'func1'}]
+        infos = [{'text': 'Say <hello> to <getgauge>', 'func': 'func'},
+                 {'text': 'Step 1', 'func': 'func1'}]
+
         for info in infos:
             registry.add_step(info['text'], info['func'], '')
 
-        self.assertEqual([info['text'] for info in infos].sort(), registry.steps().sort())
+        self.assertEqual([info['text'] for info in infos].sort(),
+                         registry.steps().sort())
+
         for info in infos:
             parsed_step_text = re.sub('<[^<]+?>', '{}', info['text'])
-            self.assertEqual(info['func'], registry.get_info_for(parsed_step_text).impl)
+            self.assertEqual(info['func'],
+                             registry.get_info_for(parsed_step_text).impl)
 
     def test_Registry_add_step_definition_with_continue_on_failure(self):
         registry.add_step('Step 1', 'func', '')
         registry.continue_on_failure('func', [RuntimeError])
 
-        self.assertEqual(True, registry.is_continue_on_failure('func', RuntimeError()))
+        self.assertEqual(True,
+                         registry.is_continue_on_failure('func',
+                                                         RuntimeError()))
 
     def test_Registry_add_step_definition_with_continue_on_failure_for_different_exceptions(self):
         registry.add_step('Step 1', 'func', '')
         registry.continue_on_failure('func', [RuntimeError])
 
-        self.assertEqual(False, registry.is_continue_on_failure('func', IndexError()))
+        self.assertEqual(False,
+                         registry.is_continue_on_failure('func', IndexError()))
 
     def test_Registry_add_step_definition_with_parent_class_continue_on_failure(self):
         registry.add_step('Step 1', 'func', '')
         registry.continue_on_failure('func', [Exception])
 
-        self.assertEqual(True, registry.is_continue_on_failure('func', RuntimeError()))
+        self.assertEqual(True,
+                         registry.is_continue_on_failure('func',
+                                                         RuntimeError()))
 
     def test_Registry_add_step_definition_with_alias(self):
         registry.add_step(['Say <hello> to <getgauge>.', 'Tell <hello> to <getgauge>.'], 'impl', '')
@@ -47,17 +57,26 @@ class RegistryTests(unittest.TestCase):
         self.assertEqual(info2.has_alias, True)
 
     def test_Registry_get_step_info(self):
-        infos = [{'text': 'Say <hello> to <getgauge>', 'func': 'func'}, {'text': 'Step 1', 'func': 'func1'}]
+        infos = [{'text': 'Say <hello> to <getgauge>', 'func': 'func'},
+                 {'text': 'Step 1', 'func': 'func1'}]
+
         for info in infos:
             registry.add_step(info['text'], info['func'], '')
 
-        self.assertEqual('Say <hello> to <getgauge>', registry.get_info_for('Say {} to {}').step_text)
-        self.assertEqual('Say {} to {}', registry.get_info_for('Say {} to {}').parsed_step_text)
+        self.assertEqual('Say <hello> to <getgauge>',
+                         registry.get_info_for('Say {} to {}').step_text)
+
+        self.assertEqual('Say {} to {}',
+                         registry.get_info_for('Say {} to {}').parsed_step_text)
+
         self.assertEqual('Step 1', registry.get_info_for('Step 1').step_text)
+
         self.assertEqual(None, registry.get_info_for('Step21').step_text)
 
     def test_Registry_is_step_implemented(self):
-        infos = [{'text': 'Say <hello> to <getgauge>', 'func': 'func'}, {'text': 'Step 1', 'func': 'func1'}]
+        infos = [{'text': 'Say <hello> to <getgauge>', 'func': 'func'},
+                 {'text': 'Step 1', 'func': 'func1'}]
+
         for info in infos:
             registry.add_step(info['text'], info['func'], '')
 
@@ -78,19 +97,27 @@ class RegistryTests(unittest.TestCase):
         self.assertFalse(registry.has_multiple_impls(infos[2]['text']))
 
     def test_Registry_get_multiple_impls(self):
-        infos = [{'text': 'Say <hello> to <getgauge>', 'func': 'func', 'line': 1},
-                 {'text': 'Say <hello> to <getgauge>', 'func': 'func', 'line': 2},
+        infos = [{'text': 'Say <hello> to <getgauge>',
+                  'func': 'func', 'line': 1},
+                 {'text': 'Say <hello> to <getgauge>',
+                  'func': 'func', 'line': 2},
                  {'text': 'Step 1', 'func': 'func1', 'line': 3}]
+
         for info in infos:
             registry.add_step(info['text'], info['func'], '', info['line'])
 
         parsed_step_text = re.sub('<[^<]+?>', '{}', infos[0]['text'])
 
         self.assertTrue(registry.has_multiple_impls(parsed_step_text))
-        self.assertEqual(set([info.line_number for info in registry.get_infos_for(parsed_step_text)]),
-                         {infos[0]['line'], infos[1]['line']})
-        self.assertEqual(set([info.step_text for info in registry.get_infos_for(parsed_step_text)]),
-                         {infos[0]['text'], infos[1]['text']})
+        self.assertEqual(
+            set([info.line_number
+                 for info in registry.get_infos_for(parsed_step_text)]),
+            {infos[0]['line'], infos[1]['line']})
+
+        self.assertEqual(
+            set([info.step_text
+                for info in registry.get_infos_for(parsed_step_text)]),
+            {infos[0]['text'], infos[1]['text']})
 
     def test_Registry_before_suite(self):
         infos = ['before suite func', 'before suite func1']
@@ -122,30 +149,47 @@ class RegistryTests(unittest.TestCase):
 
     def test_Registry_before_spec_with_tags(self):
         info1 = {'tags': None, 'func': 'before spec func'}
-        info2 = {'tags': '<A> and <b> and not <c>', 'func': 'before spec func1'}
-        info3 = {'tags': '<A> and (<b> or not <c>)', 'func': 'before spec func2'}
+        info2 = {'tags': '<A> and <b> and not <c>',
+                 'func': 'before spec func1'}
+        info3 = {'tags': '<A> and (<b> or not <c>)',
+                 'func': 'before spec func2'}
         infos = [info1, info2, info3]
+
         for info in infos:
             registry.add_before_spec(info['func'], info['tags'])
 
         self.assertEqual([info1['func']], registry.before_spec([]))
-        self.assertEqual([x['func'] for x in infos], registry.before_spec(['A', 'b']))
-        self.assertEqual([info1['func'], info3['func']], registry.before_spec(['A', 'b', 'c']))
-        self.assertEqual([info1['func'], info3['func']], registry.before_spec(['A']))
+        self.assertEqual([x['func'] for x in infos],
+                         registry.before_spec(['A', 'b']))
+
+        self.assertEqual([info1['func'], info3['func']],
+                         registry.before_spec(['A', 'b', 'c']))
+
+        self.assertEqual([info1['func'], info3['func']],
+                         registry.before_spec(['A']))
+
         self.assertEqual([info1['func']], registry.before_spec(['A', 'c']))
 
     def test_Registry_after_spec_with_tags(self):
         info1 = {'tags': None, 'func': 'after spec func'}
         info2 = {'tags': '<A> and <b> and not <c>', 'func': 'after spec func1'}
-        info3 = {'tags': '<A> and (<b> or not <c>)', 'func': 'after spec func2'}
+        info3 = {'tags': '<A> and (<b> or not <c>)',
+                 'func': 'after spec func2'}
         infos = [info1, info2, info3]
+
         for info in infos:
             registry.add_after_spec(info['func'], info['tags'])
 
         self.assertEqual([info1['func']], registry.after_spec([]))
-        self.assertEqual([x['func'] for x in infos], registry.after_spec(['A', 'b']))
-        self.assertEqual([info1['func'], info3['func']], registry.after_spec(['A', 'b', 'c']))
-        self.assertEqual([info1['func'], info3['func']], registry.after_spec(['A']))
+        self.assertEqual([x['func'] for x in infos],
+                         registry.after_spec(['A', 'b']))
+
+        self.assertEqual([info1['func'], info3['func']],
+                         registry.after_spec(['A', 'b', 'c']))
+
+        self.assertEqual([info1['func'], info3['func']],
+                         registry.after_spec(['A']))
+
         self.assertEqual([info1['func']], registry.after_spec(['A', 'c']))
 
     def test_Registry_before_scenario(self):
@@ -164,31 +208,51 @@ class RegistryTests(unittest.TestCase):
 
     def test_Registry_before_scenario_with_tags(self):
         info1 = {'tags': None, 'func': 'before scenario func'}
-        info2 = {'tags': '<A> and <b> and not <c>', 'func': 'before scenario func1'}
-        info3 = {'tags': '<A> and (<b> or not <c>)', 'func': 'before scenario func2'}
+        info2 = {'tags': '<A> and <b> and not <c>',
+                 'func': 'before scenario func1'}
+        info3 = {'tags': '<A> and (<b> or not <c>)',
+                 'func': 'before scenario func2'}
         infos = [info1, info2, info3]
+
         for info in infos:
             registry.add_before_scenario(info['func'], info['tags'])
 
-        self.assertEqual([info1['func']], registry.before_scenario([]))
-        self.assertEqual([x['func'] for x in infos], registry.before_scenario(['A', 'b']))
-        self.assertEqual([info1['func'], info3['func']], registry.before_scenario(['A', 'b', 'c']))
-        self.assertEqual([info1['func'], info3['func']], registry.before_scenario(['A']))
+        self.assertEqual([info1['func']],
+                         registry.before_scenario([]))
+
+        self.assertEqual([x['func'] for x in infos],
+                         registry.before_scenario(['A', 'b']))
+
+        self.assertEqual([info1['func'], info3['func']],
+                         registry.before_scenario(['A', 'b', 'c']))
+
+        self.assertEqual([info1['func'], info3['func']],
+                         registry.before_scenario(['A']))
+
         self.assertEqual([info1['func']], registry.before_scenario(['A', 'c']))
 
     def test_Registry_after_scenario_with_tags(self):
         info1 = {'tags': None, 'func': 'after scenario func'}
-        info2 = {'tags': '<A> and <b> and not <c>', 'func': 'after scenario func1'}
-        info3 = {'tags': '<A> and (<b> or not <c>)', 'func': 'after scenario func2'}
+        info2 = {'tags': '<A> and <b> and not <c>',
+                 'func': 'after scenario func1'}
+        info3 = {'tags': '<A> and (<b> or not <c>)',
+                 'func': 'after scenario func2'}
         infos = [info1, info2, info3]
+
         for info in infos:
             registry.add_after_scenario(info['func'], info['tags'])
 
         self.assertEqual([info1['func']], registry.after_scenario([]))
-        self.assertEqual([x['func'] for x in infos], registry.after_scenario(['A', 'b']))
-        self.assertEqual([info1['func'], info3['func']], registry.after_scenario(['A', 'b', 'c']))
-        self.assertEqual([info1['func'], info3['func']], registry.after_scenario(['A']))
-        self.assertEqual([info1['func']], registry.after_scenario(['A', 'c']))
+        self.assertEqual([x['func'] for x in infos],
+                         registry.after_scenario(['A', 'b']))
+
+        self.assertEqual([info1['func'], info3['func']],
+                         registry.after_scenario(['A', 'b', 'c']))
+
+        self.assertEqual([info1['func'], info3['func']],
+                         registry.after_scenario(['A']))
+
+        sself.assertEqual([info1['func']], registry.after_scenario(['A', 'c']))
 
     def test_Registry_before_step(self):
         infos = ['before step func', 'before step func1']
@@ -206,30 +270,47 @@ class RegistryTests(unittest.TestCase):
 
     def test_Registry_before_step_with_tags(self):
         info1 = {'tags': None, 'func': 'before step func'}
-        info2 = {'tags': '<A> and <b> and not <c>', 'func': 'before step func1'}
-        info3 = {'tags': '<A> and (<b> or not <c>)', 'func': 'before step func2'}
+        info2 = {'tags': '<A> and <b> and not <c>',
+                 'func': 'before step func1'}
+        info3 = {'tags': '<A> and (<b> or not <c>)',
+                 'func': 'before step func2'}
         infos = [info1, info2, info3]
+
         for info in infos:
             registry.add_before_step(info['func'], info['tags'])
 
         self.assertEqual([info1['func']], registry.before_step([]))
-        self.assertEqual([x['func'] for x in infos], registry.before_step(['A', 'b']))
-        self.assertEqual([info1['func'], info3['func']], registry.before_step(['A', 'b', 'c']))
-        self.assertEqual([info1['func'], info3['func']], registry.before_step(['A']))
+        self.assertEqual([x['func'] for x in infos],
+                         registry.before_step(['A', 'b']))
+
+        self.assertEqual([info1['func'], info3['func']],
+                         registry.before_step(['A', 'b', 'c']))
+
+        self.assertEqual([info1['func'], info3['func']],
+                         registry.before_step(['A']))
+
         self.assertEqual([info1['func']], registry.before_step(['A', 'c']))
 
     def test_Registry_after_step_with_tags(self):
         info1 = {'tags': None, 'func': 'after step func'}
-        info2 = {'tags': '<A> and <b> and not <c>', 'func': 'after step func1'}
-        info3 = {'tags': '<A> and (<b> or not <c>)', 'func': 'after step func2'}
+        info2 = {'tags': '<A> and <b> and not <c>',
+                 'func': 'after step func1'}
+        info3 = {'tags': '<A> and (<b> or not <c>)',
+                 'func': 'after step func2'}
         infos = [info1, info2, info3]
+
         for info in infos:
             registry.add_after_step(info['func'], info['tags'])
 
         self.assertEqual([info1['func']], registry.after_step([]))
-        self.assertEqual([x['func'] for x in infos], registry.after_step(['A', 'b']))
-        self.assertEqual([info1['func'], info3['func']], registry.after_step(['A', 'b', 'c']))
-        self.assertEqual([info1['func'], info3['func']], registry.after_step(['A']))
+        self.assertEqual([x['func'] for x in infos],
+                         registry.after_step(['A', 'b']))
+
+        self.assertEqual([info1['func'], info3['func']],
+                         registry.after_step(['A', 'b', 'c']))
+
+        self.assertEqual([info1['func'], info3['func']],
+                         registry.after_step(['A']))
         self.assertEqual([info1['func']], registry.after_step(['A', 'c']))
 
     def tearDown(self):


### PR DESCRIPTION
I tried to simplify the unit tests to the maximum while reading them, but I could not simplify everything and not insert all the tests in PEP8. I'll try another commit.