### PR TITLE
Optionally use doc strings for step-text

### DIFF
--- a/getgauge/python.py
+++ b/getgauge/python.py
@@ -4,11 +4,28 @@ import sys
 from getgauge.registry import registry, _MessagesStore
 
 
-def step(step_text):
+def step(step_def, step_text=None):
+    """
+    @step("Perform this step")
+    def my_step():
+        assert True
+
+    @step
+    def my_step():
+        '''Perform this step'''
+        assert True
+
+    my_step = step(lambda: assert True, "Perform this step")
+    """
     def _step(func):
         f_back = sys._getframe().f_back
         registry.add_step(step_text, func, f_back.f_code.co_filename, inspect.getsourcelines(func)[1])
         return func
+
+    if inspect.isfunction(step_def):
+        if step_text is None:
+            step_text = inspect.getdoc(step_def)
+        return _step(step_def)
 
     return _step
 


### PR DESCRIPTION
I would like to use doc strings as step-text since my style guide and linting tools highly encourage using docstrings with every function definition. I find it tedious to keep step-text and docstrings in sync and would like them to be the same.

**NOTE**: This is not complete. I have not looked at the runner's refactoring functionality yet and have not added tests. I just wanted to see what you, @kashishm, think of this feature request.

    @step("Perform this step")
    def my_step():
        assert True

    @step
    def my_step():
        """Perform this step"""
        assert True

    my_step = step(lambda: assert True, "Perform this step")
